### PR TITLE
Using rake to facilitate simple test runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'colored'
 gem 'rspec'
 gem 'rubocop'
 gem 'terminal-table'
+gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,10 +4,12 @@ GEM
     ast (2.3.0)
     colored (1.2)
     diff-lcs (1.2.5)
+    minitest (5.9.1)
     parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
     rainbow (2.1.0)
+    rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -37,6 +39,8 @@ PLATFORMS
 
 DEPENDENCIES
   colored
+  minitest
+  rake
   rspec
   rubocop
   terminal-table

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'minitest/autorun'
+load_paths = FileList['spec', 'lib']
+ruby_args = load_paths.pathmap('-I%p')
+
+task default: %w[test]
+
+task :test do
+  command = "ruby #{ruby_args} -rminitest/autorun spec/core_spec.rb"
+  exec command
+end


### PR DESCRIPTION
This allows for a well known, and common default, use of rake.  In this
case, it will run the tests.

There is improvements that should be made to the rake file itself, but
this is enough to show how to use it.

This commit adds minitest and rake the the dependency list, but should
really separate between what is required for "development" and what is
required for "production"